### PR TITLE
fix(ng-chartjs): move `chartjs` from dependencies to peerDependencies

### DIFF
--- a/projects/ng-chartjs/package.json
+++ b/projects/ng-chartjs/package.json
@@ -1,12 +1,10 @@
 {
   "name": "ng-chartjs",
   "version": "0.2.2",
-  "dependencies": {
-    "chart.js": "*"
-  },
   "peerDependencies": {
     "@angular/common": "*",
-    "@angular/core": "*"
+    "@angular/core": "*",
+    "chart.js": "^2.9.4"
   },
   "description": "This is a Angular chart.js library.",
   "main": "karma.conf.js",


### PR DESCRIPTION
fix for these issues https://github.com/93Alliance/ng-chartjs/issues/29#issue-876036878 and https://github.com/93Alliance/ng-chartjs/issues/28#issue-851508317.

I move `chartjs` from dependencies to peerDependencies in `projects/ng-chartjs/package.json`